### PR TITLE
Fix breaking Python image

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,7 +3,6 @@ ARG RELEASE_VERSION
 FROM ${REPOSITORY_BASE_PATH}/runner-pulumi-base-debian:${RELEASE_VERSION}
 
 USER root
-RUN apt-get install -y git python3 python3-pip python3-dev python3-venv && ln -sf python3 /usr/bin/python
-RUN pip3 install --no-cache --upgrade pip setuptools wheel
+RUN apt-get install -y git python3 python3-pip python3-dev python3-venv python3-setuptools python3-wheel && ln -sf python3 /usr/bin/python
 ENV PATH="$PATH:./.pulumi/bin"
 USER spacelift


### PR DESCRIPTION
## Description of the change

Python/pip doesn't like to install packages globally anymore. Apparently, you need to provide a new argument since Py 3.11.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (change not affecting any of the images);

## Checklists

### Development

- [ ] The affected image builds in your local environment;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
