### PR TITLE
Bump go version to 1.21

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -5,7 +5,7 @@ FROM ${REPOSITORY_BASE_PATH}/runner-pulumi-base-alpine:${RELEASE_VERSION}
 USER root
 WORKDIR /home/spacelift
 
-COPY --from=golang:1.19-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.21-alpine /usr/local/go/ /usr/local/go/
 ENV PATH=${PATH}:/usr/local/go/bin
 
 USER spacelift


### PR DESCRIPTION
## Description of the change

Upgrading the go version in the go runner to go 1.21. As go is backwards compatible thanks to module versions, this shouldn't be an issue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (change not affecting any of the images);

## Checklists

### Development

- [ ] The affected image builds in your local environment;

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
