### PR TITLE
fix: propagate download failures in base Dockerfiles

### DIFF
--- a/base-alpine/Dockerfile
+++ b/base-alpine/Dockerfile
@@ -12,8 +12,8 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
   else \
     wget -q "https://get.pulumi.com/releases/sdk/pulumi-${PULUMI_VERSION}-linux-x64.tar.gz" && \
     tar -xf pulumi-${PULUMI_VERSION}-linux-x64.tar.gz; \
-  fi; \
-  mv pulumi/* /usr/local/bin/; \
+  fi && \
+  mv pulumi/* /usr/local/bin/ && \
   rm -rf pulumi-${PULUMI_VERSION}*.tar.gz
 
 USER spacelift

--- a/base-debian/Dockerfile
+++ b/base-debian/Dockerfile
@@ -16,8 +16,8 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
   else \
     wget -q "https://get.pulumi.com/releases/sdk/pulumi-${PULUMI_VERSION}-linux-x64.tar.gz" && \
     tar -xf pulumi-${PULUMI_VERSION}-linux-x64.tar.gz; \
-  fi; \
-  mv pulumi/* /usr/local/bin/; \
+  fi && \
+  mv pulumi/* /usr/local/bin/ && \
   rm -rf pulumi-${PULUMI_VERSION}*.tar.gz
 
 USER spacelift


### PR DESCRIPTION
## Description of the change

The `RUN` commands in `base-alpine/Dockerfile` and `base-debian/Dockerfile` used semicolons (`;`) to chain commands after the `if/fi` block. This meant that if `wget` failed (e.g. HTTP 403 for a non-existent Pulumi version), the error was silently swallowed — `mv` would fail but `rm -rf` always succeeds, so the build step exited 0.

This PR replaces `;` with `&&` so any failure in the chain (wget, tar, mv) immediately aborts the Docker build.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (change not affecting any of the images);

## Checklists

### Development

- [x] The affected image builds in your local environment;

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;